### PR TITLE
Remove read-limited from default scopes

### DIFF
--- a/Provider.php
+++ b/Provider.php
@@ -34,14 +34,14 @@ class Provider extends AbstractProvider
 
     /**
      * The scopes being requested.
-     * Others include: '/activities/update','/person/update'.
+     * Others include: '/read-limited', '/activities/update','/person/update'.
      *
      * You can customise the scopes when invoking the ORCID Socialite provider
      * if this needs to change
      *
      * @var array
      */
-    protected $scopes = ['/authenticate', '/read-limited'];
+    protected $scopes = ['/authenticate'];
 
     /**
      * The separating character for the requested scopes.


### PR DESCRIPTION
When using this Orcid socialite provider, other packages are often calling ->scopes instead of ->setScopes which merges instead of sets the scopes.  I couldn't log into the the public API with this plugin as it was requesting the 'read-limited' scope which requires the member API.  

The PR removes the 'read-limited' scope - although I would also be tempted to just remove the scopes set here, and let it be required to be set.